### PR TITLE
Let search input span 2 columns.

### DIFF
--- a/source/stylesheets/modules/_search_box.scss
+++ b/source/stylesheets/modules/_search_box.scss
@@ -11,6 +11,7 @@
 
   input {
     display: block;
+    width: 100%;
     height: $gutter;
     line-height: $gutter;
     padding-left: 30px;


### PR DESCRIPTION
For some reason the `width: 100%` **is** necessary, although I can't think of any good reason, why.

Before:
![bildschirmfoto 2015-01-18 um 18 01 55](https://cloud.githubusercontent.com/assets/141632/5793240/d5525200-9f3c-11e4-9bc0-d6c99e99206a.png)

After:
![bildschirmfoto 2015-01-18 um 18 06 00](https://cloud.githubusercontent.com/assets/141632/5793235/b2c912f0-9f3c-11e4-8fb4-a17e8ff965e1.png)