### PR TITLE
Add category as award header.

### DIFF
--- a/source/index.erb
+++ b/source/index.erb
@@ -55,7 +55,10 @@ title: Energy Globe Award
     <ul class="awards-list">
       <li ng-repeat="award in filteredAwards" class="award is-category-{{ award.category }}">
         <a href="http://www.energyglobe.at/{{ award.details_link }}">
-          <img src="{{ award.images[0] }}" alt="Bild von {{ award.title }}" class="image">
+          <img src="{{ award.images[0] }}" alt="Bild von {{ award.title }}" class="image" ng-if="award.images[0]">
+          <header class="category" ng-if="!award.images[0]">
+            {{ award.category }}
+          </header>
           <div class="text">
             <div class="year">{{ award.year }}</div>
             <div class="country">{{ award.country }}</div>

--- a/source/stylesheets/modules/_awards.scss
+++ b/source/stylesheets/modules/_awards.scss
@@ -40,9 +40,13 @@
     }
   }
 
-  .image {
+  .image,
+  .category {
     width: 100%;
     height: 3 * $gutter;
+    line-height: 3 * $gutter;
+    text-align: center;
+    font-size: golden-ratio(1em, 1);
   }
 
   .text {
@@ -52,8 +56,15 @@
   }
 
   @each $category, $category-color in $category-colors {
-    .is-category-#{$category} .text {
-      border-color: $category-color;
+    .is-category-#{$category} {
+      .text {
+        border-color: $category-color;
+      }
+
+      .category {
+        background: mix($box-background, $category-color, 30%);
+        color: $category-color;
+      }
     }
   }
 

--- a/source/stylesheets/modules/_awards.scss
+++ b/source/stylesheets/modules/_awards.scss
@@ -82,6 +82,10 @@
     font-size: 0.8em;
   }
 
+  .country {
+    margin-top: golden-ratio(1em, -1);
+  }
+
   .year {
     float: right;
   }


### PR DESCRIPTION
This is my idea of making the header of awards without images more useful: I think the only property of awards that's underrepresented is the category. So I chose to put the category into the header:

![bildschirmfoto 2015-01-18 um 18 24 28](https://cloud.githubusercontent.com/assets/141632/5793326/a48427c2-9f3f-11e4-83d4-43fed737a04d.png)

If you like it, please merge it. If you don't just close the pull request.