### PR TITLE
Fix bugs of filters and awards overlapping each other.

### DIFF
--- a/source/stylesheets/_layout.scss
+++ b/source/stylesheets/_layout.scss
@@ -23,6 +23,10 @@
       top: 0;
       max-width: inherit;
       width: 100%;
+      pointer-events: none;
+      // Seems to be necessary for IE to replicate pointer-events.
+      // TODO: Check during browser testing
+      background: none !important;
 
       > .input-filters {
         margin-top: -$gutter;

--- a/source/stylesheets/_layout.scss
+++ b/source/stylesheets/_layout.scss
@@ -24,7 +24,7 @@
       max-width: inherit;
       width: 100%;
       pointer-events: none;
-      // Seems to be necessary for IE to replicate pointer-events.
+      // background seems to be necessary for IE to replicate pointer-events.
       // TODO: Check during browser testing
       background: none !important;
       z-index: 1;

--- a/source/stylesheets/_layout.scss
+++ b/source/stylesheets/_layout.scss
@@ -27,6 +27,7 @@
       // Seems to be necessary for IE to replicate pointer-events.
       // TODO: Check during browser testing
       background: none !important;
+      z-index: 1;
 
       > .input-filters {
         margin-top: -$gutter;

--- a/source/stylesheets/modules/_awards.scss
+++ b/source/stylesheets/modules/_awards.scss
@@ -27,6 +27,7 @@
 
       &:hover {
         @include transform(scale(1.05));
+        transform-style: flat;
         box-shadow: 0px 6px 10px $box-shadow-color;
         background: lighten($box-background, 0.5%);
         outline: 1px solid #CCC;


### PR DESCRIPTION
The issues are described in #24 .

Before:

![bildschirmfoto 2015-01-22 um 18 38 04](https://cloud.githubusercontent.com/assets/141632/5860992/f03fec0e-a265-11e4-8be4-db00ab63dcce.png)

After:

![bildschirmfoto 2015-01-22 um 18 36 40](https://cloud.githubusercontent.com/assets/141632/5861000/f6a8c12e-a265-11e4-8cd4-a8f501fe5ad5.png)
