### PR TITLE
Reenable award zoom transition and make it bounce a little.

### DIFF
--- a/source/stylesheets/modules/_awards.scss
+++ b/source/stylesheets/modules/_awards.scss
@@ -23,6 +23,7 @@
       color: inherit;
       display: block;
       background: $box-background;
+      // Add little bounce transition effect.
       @include transition(all 0.1s cubic-bezier(0, 1.3, 1, 1.6));
 
       &:hover {

--- a/source/stylesheets/modules/_awards.scss
+++ b/source/stylesheets/modules/_awards.scss
@@ -16,7 +16,6 @@
   .award {
     $box-shadow-color: rgba(0,0,0,0.1);
     $box-background: #EEE;
-    @include transition(all 0.1s ease-in-out);
     box-shadow: 0 0 0 $box-shadow-color;
 
     > a {
@@ -24,6 +23,7 @@
       color: inherit;
       display: block;
       background: $box-background;
+      @include transition(all 0.1s cubic-bezier(0, 1.3, 1, 1.6));
 
       &:hover {
         @include transform(scale(1.05));


### PR DESCRIPTION
I forgot to move it when I moved the whole award content into an `a` element.