### PR TITLE
make organizations searchable

### DIFF
--- a/source/javascripts/lib/wirsing/filters/search.coffee
+++ b/source/javascripts/lib/wirsing/filters/search.coffee
@@ -1,24 +1,37 @@
 #= require ../module
 
-# Returns a configurable search function that can be used
-# to filter an array of objects by searching for a term
-# within the specified property of each object.
-
 wirsing.module 'filter.search', ->
+
+  # Returns a configurable search function that can be used
+  # to filter an array of objects by searching for a term
+  # within the specified property of each object.
 
   (options) ->
 
+    # This is the function that is returned to the outside world.
+    # It takes an array of objects and returns an array of matching objects
     search = (items) ->
       if search.term.length < search.minChars
         items # dont filter
       else
-        items.filter (item) ->
-          item[search.in].toLowerCase().search(search.term.toLowerCase()) > -1
+        items.filter (item) -> search.in.some (key) ->
+          text = removeHyphens item[key]
+          isMatchingSearchTerm text, search.term
 
+    # Makes the search function completely configurable from outside
     search.configure = (config) ->
-      search.in = config.in ? search.in ? throw new Error 'option: <in> required'
+      keys = config.in ? search.in ? throw new Error 'option: <in> required'
+      search.in = [].concat keys # ensure its always an array
       search.term = config.term ? search.term ? ''
       search.minChars = config.minChars ? search.minChars ? 3
-      return search
 
-    search.configure(options)
+    # Configure the created search function before returning it
+    search.configure options
+    return search
+
+# --------- Private helpers -----------
+
+removeHyphens = (text) -> text.replace /\&shy\;/gi, ''
+
+isMatchingSearchTerm = (text, searchTerm) ->
+  text.toLowerCase().search(searchTerm.toLowerCase()) > -1

--- a/source/javascripts/services/filter_pipeline.coffee
+++ b/source/javascripts/services/filter_pipeline.coffee
@@ -6,7 +6,7 @@ EGA.service "filterPipeline", ->
   categoryChoices = filter.choices.on 'category'
   yearChoices = filter.choices.on 'year'
   countryChoices = filter.choices.on 'country'
-  search = filter.search in: 'title'
+  search = filter.search in: ['title', 'organization']
   pagination = filter.pagination perPage: 30
   filter = utils.chain [categoryChoices, yearChoices, countryChoices, search, pagination]
 

--- a/spec/javascripts/lib/wirsing/filters/search_spec.coffee
+++ b/spec/javascripts/lib/wirsing/filters/search_spec.coffee
@@ -7,7 +7,9 @@ describe 'wirsing.filter.search', ->
     @items = [
       {name: 'Dominik from Vienna', city: 'Vienna'},
       {name: 'Clemens [DönerDöner Kebab]', city: 'Vienna'},
-      {name: 'Aaron', city: 'Klosterneuburg'}
+      {name: 'Aaron', city: 'Klosterneuburg'},
+      {name: 'Vienna', city: 'Dominik'},
+      {name: 'Hyph&shy;ens can be any&shy;where', city: 'Hyphen City'},
     ]
 
   it 'allows to search for a term in specified property', ->
@@ -26,6 +28,10 @@ describe 'wirsing.filter.search', ->
     filter = search term: '(Döner){2} Kebab', in: 'name'
     expect(filter @items).toEqual [@items[1]]
 
+  it 'deals with hyphenated text correctly', ->
+    filter = search term: 'Hyphens can be anywhere', in: 'name'
+    expect(filter @items).toEqual [@items[4]]
+
   # ============ SEARCH TERM ============= #
 
   describe 'configuring search term', ->
@@ -38,7 +44,7 @@ describe 'wirsing.filter.search', ->
       @filter.configure term: 'Dominik'
       expect(@filter.term).toEqual 'Dominik'
       expect(@filter @items).toEqual [@items[0]]
-      
+
   # ============ SEARCH PROPERTY ============= #
 
   describe 'property to search in', ->
@@ -53,7 +59,11 @@ describe 'wirsing.filter.search', ->
     it 'can be changed after creation', ->
       filter = search term: 'Vienna', in: 'city'
       filter.configure in: 'name'
-      expect(filter @items).toEqual [@items[0]]
+      expect(filter @items).toEqual [@items[0], @items[3]]
+
+    it 'can also be multiple', ->
+      filter = search term: 'Vienna', in: ['city', 'name']
+      expect(filter @items).toEqual [@items[0], @items[1], @items[3]]
 
   # ============ MINIMUM CHARACTERS ============= #
 


### PR DESCRIPTION
This PR primarily makes organizations (companies) searchable in addition to the award title.
It also fixes a serious bug that was introduced with hyphenation – many searches didn't match anymore because the search was not updated to remove the hyphens `&shy;` from the searchable properties :wink:

![bildschirmfoto 2015-01-29 um 11 38 12](https://cloud.githubusercontent.com/assets/172414/5956200/630b1606-a7ab-11e4-898b-81f155e5ed45.png)
